### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
+name: CI
 permissions:
   contents: read
-name: CI
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/anpdgovbr/shared-ui/security/code-scanning/2](https://github.com/anpdgovbr/shared-ui/security/code-scanning/2)

The best way to fix the problem is to add a `permissions` block at the root level of the workflow file (`.github/workflows/ci.yml`). By setting `permissions: contents: read`, both the `build` and `lint` jobs will only have read access to repository contents, which is the minimum required for the operations performed by these jobs. This reduces the risk of accidental or malicious repository changes and adheres to the principle of least privilege. The edit should be made after the `name` field and before the `on` field for maximum clarity and to apply to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
