### PR TITLE
fix(theme): move state styleOverrides into root with MUI selectors

### DIFF
--- a/docs/COMO_USAR_TEMA.md
+++ b/docs/COMO_USAR_TEMA.md
@@ -306,3 +306,19 @@ import '@govbr-ds/core/dist/core-tokens.min.css'
 - 🎨 **[Gov.br DS](https://gov.br/ds)** - Design System oficial
 - 📝 **[ADICIONAR_COMPONENTE.md](./ADICIONAR_COMPONENTE.md)** - Como criar novos componentes
 - 🔧 **[MUI Theme](https://mui.com/material-ui/customization/theming/)** - Documentação de temas MUI
+
+## 🧪 Validação rápida de overrides do tema
+
+Se você editar `src/theme/components/*` e ajustar `styleOverrides`, valide manualmente que não há warnings do MUI sobre especificidade (ex.: mensagens que indicam para usar `&.Mui-focused` em vez de `focused` no nível superior):
+
+1. Rode localmente `npm run check` (lint + typecheck) e `npm run build`.
+2. Abra a aplicação de exemplo ou Storybook; inspecione o console do navegador ao montar componentes de formulário (TextField, InputLabel, FormLabel, FormHelperText).
+3. Procure por warnings como: "The MuiFormLabel component increases the CSS specificity of the focused internal state... use '&.Mui-focused' syntax." Se não aparecerem, o override está correto.
+
+Esta nota é especialmente importante ao mover chaves de estado (focused, error, disabled, filled) para dentro de `styleOverrides.root` usando os seletores:
+
+- focused -> `&.Mui-focused`
+- error -> `&.Mui-error`
+- disabled -> `&.Mui-disabled`
+- filled -> `&.Mui-filled`
+

--- a/src/theme/components/FormControlLabel.ts
+++ b/src/theme/components/FormControlLabel.ts
@@ -49,6 +49,13 @@ export const MuiFormControlLabelOverrides: Components['MuiFormControlLabel'] = {
       //     color: 'var(--interactive, #1351B4)',
       //   },
       // },
+
+      '&.Mui-disabled': {
+        '& .MuiFormControlLabel-label': {
+          color: 'var(--gray-60, #888888)',
+          cursor: 'not-allowed',
+        },
+      },
     },
     label: {
       fontSize: 'var(--font-size-scale-base, 1rem)', // 1rem
@@ -72,12 +79,10 @@ export const MuiFormControlLabelOverrides: Components['MuiFormControlLabel'] = {
       //   },
       // },
     },
-    disabled: {
-      '& .MuiFormControlLabel-label': {
-        color: 'var(--gray-60, #888888)',
-        cursor: 'not-allowed',
-      },
-    },
+    // disabled state merged into root to avoid top-level state keys
+    // mantém o slot label intacto para regras diretas
+    // Caso seja necessário comportamento específico do root para disabled,
+    // pode-se usar '&.Mui-disabled' dentro do root acima.
 
     // Posicionamentos do label
     labelPlacementStart: {

--- a/src/theme/components/FormHelperText.ts
+++ b/src/theme/components/FormHelperText.ts
@@ -36,32 +36,26 @@ export const MuiFormHelperTextOverrides: Components['MuiFormHelperText'] = {
       // Animação de entrada
       // transition: 'opacity 0.2s ease-in-out',
       // opacity: 1,
-    },
-    filled: {
-      marginLeft: 0, // consistência com root
-      paddingBottom: 'var(--spacing-scale-2xh, 0.25rem)', // 4px - espaçamento inferior
 
-      // FALTANDO: paddingLeft: 'var(--spacing-scale-1xh, 0.75rem)', // alinhamento com filled input
-    },
-    error: {
-      fontSize: 'var(--font-size-scale-down-01, 0.833rem)', // 0.833rem - ligeiramente menor
-      marginTop: 'var(--spacing-scale-2xh, 0.25rem)', // 4px
-      marginLeft: 'var(--spacing-scale-half, 0.5rem)', // 8px - pequena indentação para destaque
-      fontFamily: 'var(--font-family-base, "Rawline", "Raleway", sans-serif)',
-      color: 'var(--feedback-error-vivid, #D04F4F)',
+      // filled variant adjustments moved into root with selector
+      '&.Mui-filled': {
+        marginLeft: 0, // consistência com root
+        paddingBottom: 'var(--spacing-scale-2xh, 0.25rem)', // 4px - espaçamento inferior
+      },
 
-      // PROPRIEDADES FALTANDO - Implementar se necessário:
-      // fontWeight: 'var(--font-weight-medium, 500)', // destaque para erro
-      // '&::before': {
-      //   content: '"⚠ "', // ícone de alerta
-      //   fontWeight: 'bold',
-      // },
-      // animation: 'shake 0.3s ease-in-out', // animação de entrada
-    },
-    disabled: {
-      color: 'var(--gray-60, #888888)', // cor mais clara para desabilitado
+      // error state moved into root
+      '&.Mui-error': {
+        fontSize: 'var(--font-size-scale-down-01, 0.833rem)', // 0.833rem - ligeiramente menor
+        marginTop: 'var(--spacing-scale-2xh, 0.25rem)', // 4px
+        marginLeft: 'var(--spacing-scale-half, 0.5rem)', // 8px - pequena indentação para destaque
+        fontFamily: 'var(--font-family-base, "Rawline", "Raleway", sans-serif)',
+        color: 'var(--feedback-error-vivid, #D04F4F)',
+      },
 
-      // FALTANDO: opacity: 0.7, // redução de opacidade
+      // disabled state moved into root
+      '&.Mui-disabled': {
+        color: 'var(--gray-60, #888888)', // cor mais clara para desabilitado
+      },
     },
 
     // SLOTS FALTANDO - Implementar se necessário:

--- a/src/theme/components/FormLabel.ts
+++ b/src/theme/components/FormLabel.ts
@@ -36,18 +36,20 @@ export const MuiFormLabelOverrides: Components['MuiFormLabel'] = {
       //   content: '" *"',
       //   color: 'var(--feedback-error-vivid, #D04F4F)',
       // },
-    },
-    focused: {
-      color: 'var(--interactive, #1351B4)',
-      // FALTANDO: fontWeight: 'var(--font-weight-semi-bold, 600)', // mais destaque no foco
-    },
-    error: {
-      color: 'var(--feedback-error-vivid, #D04F4F)',
-      // FALTANDO: fontWeight: 'var(--font-weight-semi-bold, 600)', // destaque no erro
-    },
-    disabled: {
-      color: 'var(--gray-60, #888888)',
-      // FALTANDO: cursor: 'not-allowed', // indicação visual
+
+      // Estados movidos para dentro de root para evitar warnings do MUI sobre especificidade
+      '&.Mui-focused': {
+        color: 'var(--interactive, #1351B4)',
+        // FALTANDO: fontWeight: 'var(--font-weight-semi-bold, 600)', // mais destaque no foco
+      },
+      '&.Mui-error': {
+        color: 'var(--feedback-error-vivid, #D04F4F)',
+        // FALTANDO: fontWeight: 'var(--font-weight-semi-bold, 600)', // destaque no erro
+      },
+      '&.Mui-disabled': {
+        color: 'var(--gray-60, #888888)',
+        // FALTANDO: cursor: 'not-allowed', // indicação visual
+      },
     },
 
     // SLOTS FALTANDO - Implementar se necessário:


### PR DESCRIPTION
Esse PR move chaves de estado (focused, error, disabled, filled) usadas em src/theme/components/* para dentro de styleOverrides.root usando selectors do MUI (&.Mui-focused, &.Mui-error, &.Mui-disabled, &.Mui-filled). Isso previne warnings do MUI sobre especificidade de CSS.\n\nArquivos alterados:\n- src/theme/components/FormLabel.ts\n- src/theme/components/FormHelperText.ts\n- src/theme/components/FormControlLabel.ts\n- docs/COMO_USAR_TEMA.md (nota de validação rápida)\n\nChecklist de validação:\n- [x] moveu focused/error/disabled/filled para dentro de root com os seletores apropriados\n- [x] manteve propriedades existentes em root e mesclou seletores\n- [x] atualizou documentação com teste manual rápido\n- [x] rodou npm run check e npm run build com sucesso localmente\n